### PR TITLE
refactor: prepare for static deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+

--- a/src/services/autoBackup.ts
+++ b/src/services/autoBackup.ts
@@ -18,7 +18,8 @@ export interface BackupData {
 export class AutoBackupService {
   private static readonly BACKUP_KEY = 'salary_dashboard_backup';
   private static readonly BACKUP_FILENAME = '/backup/salary_dashboard_backup.json';
-  private static backupTimeout: NodeJS.Timeout | null = null;
+  // Use browser-compatible timeout type for static deployments
+  private static backupTimeout: ReturnType<typeof setTimeout> | null = null;
   private static lastBackupHash: string = '';
 
   /**
@@ -142,7 +143,7 @@ export class AutoBackupService {
   private static async saveBackupForManualUpdate(backupData: BackupData): Promise<void> {
     // Store the backup data in a format that can be easily retrieved
     const backupContent = JSON.stringify(backupData, null, 2);
-    
+
     // Create a hidden element with the backup content for easy copying
     const backupElement = document.getElementById('backup-content') || document.createElement('div');
     backupElement.id = 'backup-content';
@@ -152,11 +153,20 @@ export class AutoBackupService {
     if (!document.getElementById('backup-content')) {
       document.body.appendChild(backupElement);
     }
-    
+
     // Also make it available via a global variable for easy access
     (window as any).salaryDashboardBackup = backupData;
-    
-
+    // Trigger a file download so users can manually save the backup
+    const blob = new Blob([backupContent], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'salary_dashboard_backup.json';
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   }
 
   /**

--- a/src/services/tempFieldStorage.ts
+++ b/src/services/tempFieldStorage.ts
@@ -11,7 +11,8 @@ interface TempFieldChange {
 export class TempFieldStorageService {
   private static readonly TEMP_STORAGE_KEY = 'salary_dashboard_temp_changes';
   private static readonly MAX_TEMP_AGE = 5 * 60 * 1000; // 5 minutes
-  private static backupTimeout: NodeJS.Timeout | null = null;
+  // Use browser-friendly timeout type instead of NodeJS.Timeout
+  private static backupTimeout: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Store a temporary field change

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,10 +17,5 @@ export default defineConfig({
       'papaparse',
       'dexie'
     ]
-  },
-  // Additional server configuration for better development experience
-  server: {
-    // Force dependency re-optimization on server restart
-    force: true
   }
 })


### PR DESCRIPTION
## Summary
- replace NodeJS timeout types with browser-compatible equivalents
- enable client-side backup download via Blob URL
- remove dev-only server config and ignore build artifacts

## Testing
- `npm test -- --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a71e8fe198832fa90af27585b1aa35