### PR TITLE
Enable GitLab Pages static build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+image: node:18
+
+pages:
+  stage: deploy
+  cache:
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+    - npm run build
+    - rm -rf public
+    - mv dist public
+  artifacts:
+    paths:
+      - public
+  only:
+    - main

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,17 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Use relative paths in the production build so the app can be served from a
+  // subdirectory (e.g. GitLab Pages). For local development we keep the root
+  // base to preserve existing behaviour.
+  base: command === 'build' ? './' : '/',
   plugins: [react()],
   optimizeDeps: {
     // Exclude problematic dependencies from Vite's dependency optimization
     exclude: [
       'plotly.js', // Large library that can cause optimization issues
-      '@e965/xlsx'  // Excel library that may have compatibility issues
+      '@e965/xlsx' // Excel library that may have compatibility issues
     ],
     // Force include common dependencies that should be optimized
     include: [
@@ -18,4 +22,4 @@ export default defineConfig({
       'dexie'
     ]
   }
-})
+}))


### PR DESCRIPTION
## Summary
- configure Vite to output relative paths for subdirectory hosting
- add GitLab CI pipeline that builds and publishes the site for GitLab Pages

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Unexpected any and unused variable errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a72aed6558832fad6d1b14469e6a36