### PR TITLE
Limit currency converter to single API

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ EMP002,3.8,1,9
 
 ## 💱 Currency Conversion
 
-- **Real-time exchange rates** fetched from live APIs during data import
-- **1-hour caching** to ensure current rates while avoiding API limits
+- **Real-time exchange rates** fetched from a single live API (exchangerate-api.com) during data import
+- **15-minute caching** to ensure current rates while avoiding API limits
 - **Automatic USD conversion** for all foreign currencies (EUR, GBP, INR, etc.)
-- **Fallback rates** used if API is unavailable (static rates from 2024)
+- **Fallback rates** used if the API is unavailable (static rates from 2024)
 - **Rate refresh** occurs when you re-import data files
 
 ## 🛠️ Technology Stack

--- a/REAL_TIME_CURRENCY.md
+++ b/REAL_TIME_CURRENCY.md
@@ -1,157 +1,43 @@
 # Real-Time Currency Conversion Guide
 
-## 🚀 Enhanced for Up-to-Date Rates
+## Live Exchange Rates
 
-Your salary dashboard now prioritizes the most current exchange rates available! Here's what's been implemented:
+The dashboard retrieves exchange rates from a single external service: **exchangerate-api.com**. All other application data remains local to the browser.
 
-## ⚡ **Real-Time Features**
+## Caching Strategy
 
-### **1. Multiple API Sources**
-The system now tries **5 different currency APIs** in order:
+- **Cache Duration**: 15 minutes by default
+- **Timeout**: 8 seconds for each request
+- **Real-Time Mode**: Optionally initialize with a 10‑minute cache for fresher rates
 
-1. **exchangerate-api.com** - Free, reliable, updated daily
-2. **exchangerate.host** - Free, no API key required, real-time
-3. **currencybeacon.com** - Free tier, professional-grade data
-4. **fixer.io** - Premium service (requires API key)
-5. **freecurrencyapi.net** - Backup service (requires API key)
+## Helpful Methods
 
-### **2. Aggressive Fresh Data Strategy**
-- **Cache Duration**: Reduced to 15 minutes (was 1 hour)
-- **Retry Attempts**: Increased to 5 attempts per conversion
-- **Timeout**: Extended to 8 seconds for better API success
-- **Real-time Mode**: Optional 10-minute cache for ultra-fresh rates
-
-### **3. Smart Caching with Freshness Indicators**
 ```typescript
-// The system now shows you exactly how fresh your rates are:
-📋 Using cached rate (3min old): 1.0847
-🗑️  Cache expired (18min old), fetching fresh rate
-✅ Got live rate from API 1: 1.0851 (api)
-```
+// Bypass caches and fetch the latest rate
+const fresh = await CurrencyConverter.forceRefreshRate('EUR', 'USD');
 
-## 🎯 **New Methods for Maximum Freshness**
-
-### **Force Refresh Rate**
-```typescript
-// Bypass all caches and get the absolute latest rate
-const freshRate = await CurrencyConverter.forceRefreshRate('EUR', 'USD');
-```
-
-### **Get Freshest Rate**
-```typescript
-// Try API first, then fall back to cache if needed
+// Try API first, then fall back to cache or static data
 const rate = await CurrencyConverter.getFreshestRate('GBP', 'USD');
+
+// Initialize converter with real-time settings
+CurrencyConverter.initializeForRealTime();
 ```
 
-### **Real-Time Initialization**
-```typescript
-// Initialize with ultra-fresh 10-minute cache
-CurrencyConverter.initializeForRealTime(optionalApiKey);
-```
+## Priority Order
 
-## 📊 **How It Works in Your Static App**
+1. **🌐 Live API Call** – exchange-rate request
+2. **📋 Recent Cache** – in-memory cache if within 15 minutes
+3. **💾 IndexedDB Cache** – persisted data for offline use
+4. **📊 Fallback Rates** – static 2024 exchange rates
 
-### **Priority Order (Real-Time Mode)**
-1. **🌐 Live API Call** - Always tries fresh data first
-2. **📋 Recent Cache** - Uses if less than 10-15 minutes old
-3. **💾 IndexedDB Cache** - Persistent storage for offline use
-4. **📊 Fallback Rates** - Static rates if all else fails
+## Console Logging Example
 
-### **Console Logging**
-You'll see detailed logs showing exactly what's happening:
 ```
 🚀 Currency Converter initialized for REAL-TIME priority
    - Cache duration: 10 minutes
-   - Enhanced API retry attempts
-   - Multiple API sources for redundancy
 
-🔄 Fetching live rates for EUR → USD
-✅ Got live rate from API 1: 1.0851 (api)
+🔄 Fetching live rate for EUR → USD
+✅ Got live rate: 1.0851 (api)
 ```
 
-## 🔧 **Configuration Options**
-
-### **Standard Real-Time Mode** (Default)
-- Cache: 15 minutes
-- Retries: 5 attempts
-- Timeout: 8 seconds
-
-### **Ultra Real-Time Mode**
-```typescript
-CurrencyConverter.initializeForRealTime();
-// Cache: 10 minutes
-// Retries: 6 attempts  
-// Timeout: 10 seconds
-```
-
-### **Custom Configuration**
-```typescript
-CurrencyConverter.initialize({
-  cacheDurationMs: 5 * 60 * 1000,  // 5 minutes
-  retryAttempts: 8,                // 8 attempts
-  timeoutMs: 12000,                // 12 seconds
-  apiKey: 'your-api-key'           // For premium services
-});
-```
-
-## 🌐 **API Key Setup (Optional)**
-
-For even better rates, you can add API keys:
-
-### **Free API Keys**
-- **Fixer.io**: 100 requests/month free
-- **FreeCurrencyAPI**: 5,000 requests/month free
-- **CurrencyBeacon**: 5,000 requests/month free
-
-### **Setup**
-```typescript
-// In your app initialization
-CurrencyConverter.initializeForRealTime('your-fixer-api-key');
-```
-
-## 📈 **Performance Impact**
-
-### **Benefits**
-- ✅ **Most accurate rates** - Always tries live data first
-- ✅ **Multiple fallbacks** - 5 different API sources
-- ✅ **Smart caching** - Reduces unnecessary API calls
-- ✅ **Offline capable** - Works without internet
-
-### **Considerations**
-- 🌐 **Requires internet** for live rates (falls back gracefully)
-- ⏱️ **Slight delay** on first load (fetching fresh rates)
-- 📊 **API limits** - Free tiers have request limits
-
-## 🔍 **Testing Real-Time Rates**
-
-### **In Browser Console**
-```javascript
-// Test force refresh
-await CurrencyConverter.forceRefreshRate('EUR', 'USD');
-
-// Test freshest rate
-await CurrencyConverter.getFreshestRate('GBP', 'USD');
-
-// Check cache status
-CurrencyConverter.getCacheStats();
-```
-
-### **Visual Indicators**
-The app will show in console logs:
-- When rates are fetched live vs cached
-- How old cached rates are
-- Which API source provided the rate
-- Success/failure of each API attempt
-
-## 🎯 **Best Practices**
-
-1. **Let it auto-refresh** - The system handles freshness automatically
-2. **Check console logs** - See exactly what's happening with rates
-3. **Add API keys** - For higher rate limits and better reliability
-4. **Monitor performance** - Watch for any slowdowns in your use case
-
-## 🚀 **Result**
-
-Your static salary dashboard now provides **the most up-to-date currency conversion possible** while maintaining full offline capability and fast performance through intelligent caching!
-
-The system will always try to give you live rates first, but gracefully falls back to ensure your app never breaks due to currency conversion issues.
+This configuration maintains a minimal external footprint while still providing up-to-date currency information.

--- a/src/services/dataProcessor.ts
+++ b/src/services/dataProcessor.ts
@@ -28,7 +28,6 @@ export interface ProcessingOptions extends JoinOptions {
   skipValidation?: boolean;
   autoGenerateFields?: boolean;
   convertCurrencies?: boolean; // Default: true - convert all salaries to USD
-  currencyApiKey?: string; // Optional API key for real-time rates
 }
 
 export class DataProcessor {
@@ -83,7 +82,6 @@ export class DataProcessor {
       // Initialize currency converter if needed
       if (options.convertCurrencies !== false) {
         CurrencyConverter.initialize({
-          apiKey: options.currencyApiKey,
           fallbackToStaticRates: true,
         });
       }

--- a/src/services/dataStorage.ts
+++ b/src/services/dataStorage.ts
@@ -51,7 +51,6 @@ export interface SessionData {
   };
   processingOptions: {
     convertCurrencies: boolean;
-    currencyApiKey?: string;
     joinStrategy: string;
   };
 }

--- a/src/utils/testDataCaching.ts
+++ b/src/utils/testDataCaching.ts
@@ -91,7 +91,6 @@ const sampleSession: SessionData = {
   },
   processingOptions: {
     convertCurrencies: true,
-    currencyApiKey: '',
     joinStrategy: 'email-first',
   },
 };


### PR DESCRIPTION
## Summary
- restrict currency conversion to exchangerate-api.com and drop API key handling
- remove currency API key fields from processing options and storage
- update documentation for single authorized currency API usage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any/no-unused-vars)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7aefcee24832f96ae88842095ca3f