### PR TITLE
Validate policies on import with violation summary

### DIFF
--- a/src/components/Dashboard.module.css
+++ b/src/components/Dashboard.module.css
@@ -131,6 +131,10 @@
   width: 100%;
 }
 
+.violationSummary {
+  margin: 1rem 0;
+}
+
 .metricsSection {
   background: white;
   border-radius: 1rem;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import type { FileUploadResult, PolicyViolation } from '../types/employee';
 import { BudgetInput } from './BudgetInput';
 import { BudgetSummary } from './BudgetSummary';
@@ -6,6 +6,7 @@ import { MetricsHeatMap } from './MetricsHeatMap';
 import { EmployeeTable } from './EmployeeTable';
 import EmployeeDetail from './EmployeeDetail';
 import PolicyViolationAlert from './PolicyViolationAlert';
+import PolicyViolationSummary from './PolicyViolationSummary';
 import { CSVExporter } from '../services/csvExporter';
 import { PolicyValidator } from '../utils/policyValidation';
 import styles from './Dashboard.module.css';
@@ -40,6 +41,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   const [policyViolations, setPolicyViolations] = useState<PolicyViolation[]>([]);
   const [isExporting, setIsExporting] = useState(false);
   const [pendingAction, setPendingAction] = useState<'export' | 'validate' | null>(null);
+  const [importViolations, setImportViolations] = useState<PolicyViolation[]>([]);
 
   // Calculate current budget usage and metrics
   const budgetMetrics = useMemo(() => {
@@ -147,6 +149,23 @@ export const Dashboard: React.FC<DashboardProps> = ({
       })
       .filter(emp => emp !== null); // Remove any failed mappings
   }, [employeeData]);
+
+  // Validate policies after data import
+  useEffect(() => {
+    if (employeeData.length === 0) {
+      setImportViolations([]);
+      return;
+    }
+    const violations = PolicyValidator.validateAllEmployees(
+      employeeData,
+      {
+        totalBudget,
+        currentBudgetUsage: budgetMetrics.totalProposedRaises,
+        employeeCount: employeeData.length
+      }
+    );
+    setImportViolations(violations);
+  }, [employeeData, totalBudget, budgetMetrics.totalProposedRaises]);
 
 
   // Handle employee selection for details view
@@ -362,7 +381,11 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 utilizationPercent={budgetMetrics.budgetUtilization}
               />
             </div>
-
+            {importViolations.length > 0 && (
+              <div className={styles.violationSummary}>
+                <PolicyViolationSummary violations={importViolations} />
+              </div>
+            )}
 
             {/* Metrics Heat Map */}
             <div className={styles.heatMapSection}>

--- a/src/components/PolicyViolationSummary.module.css
+++ b/src/components/PolicyViolationSummary.module.css
@@ -1,0 +1,51 @@
+.card {
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.title {
+  margin: 0 0 0.5rem 0;
+  font-weight: 600;
+  color: #92400e;
+}
+
+.typeSection {
+  margin-bottom: 0.5rem;
+}
+
+.typeHeader {
+  display: flex;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  align-items: center;
+}
+
+.typeName {
+  flex: 1;
+  text-align: left;
+  text-transform: capitalize;
+}
+
+.typeCount {
+  margin-left: 0.5rem;
+  font-weight: 600;
+}
+
+.expandIcon {
+  margin-left: 0.5rem;
+}
+
+.employeeList {
+  list-style: disc;
+  margin: 0.25rem 0 0.5rem 1.5rem;
+  padding: 0;
+}
+
+.employeeItem {
+  margin: 0.25rem 0;
+}

--- a/src/components/PolicyViolationSummary.tsx
+++ b/src/components/PolicyViolationSummary.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo, useState } from 'react';
+import type { PolicyViolation } from '../types/employee';
+import styles from './PolicyViolationSummary.module.css';
+
+interface PolicyViolationSummaryProps {
+  violations: PolicyViolation[];
+}
+
+interface GroupedViolations {
+  [type: string]: PolicyViolation[];
+}
+
+const PolicyViolationSummary: React.FC<PolicyViolationSummaryProps> = ({ violations }) => {
+  const grouped = useMemo(() => {
+    return violations.reduce<GroupedViolations>((acc, violation) => {
+      if (!acc[violation.type]) {
+        acc[violation.type] = [];
+      }
+      acc[violation.type].push(violation);
+      return acc;
+    }, {});
+  }, [violations]);
+
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggle = (type: string) => {
+    setExpanded(prev => ({ ...prev, [type]: !prev[type] }));
+  };
+
+  const types = Object.keys(grouped);
+  if (types.length === 0) return null;
+
+  return (
+    <div className={styles.card}>
+      <h3 className={styles.title}>⚠️ Policy Violations</h3>
+      {types.map(type => (
+        <div key={type} className={styles.typeSection}>
+          <button className={styles.typeHeader} onClick={() => toggle(type)}>
+            <span className={styles.typeName}>{type.replace(/_/g, ' ')}</span>
+            <span className={styles.typeCount}>{grouped[type].length}</span>
+            <span className={styles.expandIcon}>{expanded[type] ? '▼' : '▶'}</span>
+          </button>
+          {expanded[type] && (
+            <ul className={styles.employeeList}>
+              {grouped[type].map((v, index) => (
+                <li key={index} className={styles.employeeItem}>
+                  {v.employeeName || v.employeeId || 'Unknown'}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PolicyViolationSummary;


### PR DESCRIPTION
## Summary
- run `PolicyValidator.validateAllEmployees` automatically after loading employee data
- show grouped policy warnings in a drill-down card

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa2babb2bc832fb684c32e01d82956