### PR TITLE
Add range breach metrics card with quick filters

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { BudgetInput } from './BudgetInput';
 import { BudgetSummary } from './BudgetSummary';
 import { MetricsHeatMap } from './MetricsHeatMap';
 import { EmployeeTable } from './EmployeeTable';
+import { MetricsCards } from './MetricsCards';
 import EmployeeDetail from './EmployeeDetail';
 import PolicyViolationAlert from './PolicyViolationAlert';
 import { CSVExporter } from '../services/csvExporter';
@@ -21,6 +22,14 @@ interface DashboardProps {
   onBudgetChange: (budget: number, currency: string) => void;
 }
 
+type EmployeeFilter =
+  | 'all'
+  | 'withRaises'
+  | 'highPerformers'
+  | 'atRisk'
+  | 'belowRange'
+  | 'aboveRange';
+
 export const Dashboard: React.FC<DashboardProps> = ({
   employeeData,
   uploadedFiles,
@@ -34,6 +43,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   // View state
   const [currentView, setCurrentView] = useState<'overview' | 'table'>('overview');
   const [selectedEmployee, setSelectedEmployee] = useState<any>(null);
+  const [tableFilter, setTableFilter] = useState<EmployeeFilter>('all');
   
   // Export and validation state
   const [showPolicyAlert, setShowPolicyAlert] = useState(false);
@@ -185,8 +195,14 @@ export const Dashboard: React.FC<DashboardProps> = ({
   }, []);
 
   const switchToTable = useCallback(() => {
+    setTableFilter('all');
     setCurrentView('table');
     setSelectedEmployee(null);
+  }, []);
+
+  const handleQuickFilter = useCallback((filter: EmployeeFilter) => {
+    setTableFilter(filter);
+    setCurrentView('table');
   }, []);
 
   // Handle closing detail view
@@ -362,7 +378,18 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 utilizationPercent={budgetMetrics.budgetUtilization}
               />
             </div>
-
+            
+            {/* Metrics Cards */}
+            <div className={styles.metricsSection}>
+              <MetricsCards
+                totalEmployees={employeeData.length}
+                totalBudget={totalBudget}
+                budgetCurrency={budgetCurrency}
+                budgetMetrics={budgetMetrics}
+                employeeData={employeeData}
+                onQuickFilter={handleQuickFilter}
+              />
+            </div>
 
             {/* Metrics Heat Map */}
             <div className={styles.heatMapSection}>
@@ -415,6 +442,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
               budgetCurrency={budgetCurrency}
               totalBudget={totalBudget}
               currentBudgetUsage={budgetMetrics.totalProposedRaises}
+              initialFilterBy={tableFilter}
             />
           </div>
         )}

--- a/src/components/MetricsCards.module.css
+++ b/src/components/MetricsCards.module.css
@@ -88,6 +88,10 @@
   background: linear-gradient(90deg, #ef4444, #dc2626);
 }
 
+.rangeCard::before {
+  background: linear-gradient(90deg, #f87171, #b91c1c);
+}
+
 .statsCard::before {
   background: linear-gradient(90deg, #06b6d4, #0891b2);
 }
@@ -164,6 +168,15 @@
   background: #f8fafc;
   border-radius: 0.5rem;
   border: 1px solid #e2e8f0;
+}
+
+.secondaryMetric.clickable {
+  cursor: pointer;
+}
+
+.secondaryMetric.clickable:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
 }
 
 .secondaryLabel {


### PR DESCRIPTION
## Summary
- compute salary range breaches and expose quick filters in metrics cards
- allow employee table to filter by salary range breaches
- wire dashboard to display new range breach card and navigate to filtered view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2b8c42b0832f98d79a1fc8283e4d