### PR TITLE
Fix EmployeeDetail two-column layout

### DIFF
--- a/src/components/EmployeeDetail.module.css
+++ b/src/components/EmployeeDetail.module.css
@@ -106,8 +106,7 @@
 
 /* Content Grid */
 .contentGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
   gap: 24px;
   padding: 24px;
   min-height: 400px;
@@ -115,17 +114,10 @@
 
 .leftColumn,
 .rightColumn {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 20px;
-}
-
-.leftColumn {
-  grid-column: 1;
-}
-
-.rightColumn {
-  grid-column: 2;
 }
 
 /* Cards */


### PR DESCRIPTION
## Summary
- simplify EmployeeDetail layout using flexbox
- ensure left and right card columns render side by side

## Testing
- `npm test`
- `npm run lint` *(fails: many `@typescript-eslint/no-explicit-any` and hook order errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8f112164832f98512dbd89ed091f