### PR TITLE
Ensure employee detail cards render in two columns

### DIFF
--- a/src/components/EmployeeDetail.module.css
+++ b/src/components/EmployeeDetail.module.css
@@ -106,15 +106,16 @@
 
 /* Content Grid */
 .contentGrid {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 24px;
   padding: 24px;
   min-height: 400px;
+  align-items: start;
 }
 
 .leftColumn,
 .rightColumn {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -868,13 +869,7 @@
   .contentGrid {
     grid-template-columns: 1fr;
   }
-  
-  /* Ensure both columns stack in single-column layout */
-  .leftColumn,
-  .rightColumn {
-    grid-column: 1;
-  }
-  
+
   .modalContent {
     max-width: 800px;
   }


### PR DESCRIPTION
## Summary
- Switch employee detail modal to CSS grid for two-column layout
- Maintain responsive single-column stacking on small screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac92f8e6e0832fbefdb9165da1e5b5