### PR TITLE
feat: support Workday salary review import

### DIFF
--- a/src/services/__tests__/proposalImporter.test.ts
+++ b/src/services/__tests__/proposalImporter.test.ts
@@ -1,0 +1,56 @@
+import { ProposalImporter } from '../../services/proposalImporter';
+import type { Employee } from '../../types/employee';
+
+describe('ProposalImporter', () => {
+  const baseEmployees: Employee[] = [
+    {
+      employeeId: 'EMP001',
+      email: '',
+      name: 'John Smith',
+      firstName: 'John',
+      lastName: 'Smith',
+      country: 'US',
+      currency: 'USD',
+      baseSalary: 50000,
+      baseSalaryUSD: 50000,
+      basePayAllCountries: 50000,
+      timeType: undefined,
+      salary: undefined,
+      fte: undefined,
+      comparatio: 100,
+      timeInRole: 12,
+      performanceRating: undefined,
+      retentionRisk: 50,
+      proposedRaise: 0,
+      newSalary: 50000,
+      percentChange: 0,
+    },
+  ];
+
+  function createFile(content: string): File {
+    return new File([content], 'test.csv', { type: 'text/csv' });
+  }
+
+  it('imports existing proposal format', async () => {
+    const csv = 'employee number,proposed raise (percent),proposed salary\n' +
+      'EMP001,5%,52500';
+    const result = await ProposalImporter.importProposals(createFile(csv), baseEmployees);
+    expect(result.success).toBe(true);
+    const emp = result.updatedEmployees[0];
+    expect(emp.proposedRaise).toBeCloseTo(2500);
+    expect(emp.newSalary).toBeCloseTo(52500);
+  });
+
+  it('imports new Workday proposal format', async () => {
+    const csv = 'Associate ID,Associate,Current Base Pay All Countries,Currency,Merit Increase Amount,Merit Increase %,New Base Pay All Countries,Merit Increase Priority/Recommendation,Salary Adjustment Notes\n' +
+      'EMP001,John Smith,50000,USD,3000,6%,53000,High,Great performance';
+    const result = await ProposalImporter.importProposals(createFile(csv), baseEmployees);
+    expect(result.success).toBe(true);
+    const emp = result.updatedEmployees[0];
+    expect(emp.proposedRaise).toBe(3000);
+    expect(emp.newSalary).toBe(53000);
+    expect(emp.percentChange).toBeCloseTo(6);
+    expect((emp as any).salaryRecommendation).toBe('High');
+    expect((emp as any).adjustmentNotes).toBe('Great performance');
+  });
+});

--- a/src/services/dataJoiner.ts
+++ b/src/services/dataJoiner.ts
@@ -180,12 +180,22 @@ export class DataJoiner {
     employee.lastName = normalizedName.lastName;
 
     // Calculate comparatio using centralized logic
-    employee.comparatio = calculateComparatio(salaryData);
+    employee.comparatio = salaryData.comparatio ?? calculateComparatio(salaryData);
 
-    // Initialize raise-related fields
-    employee.proposedRaise = 0;
-    employee.newSalary = getDisplaySalary(salaryData);
-    employee.percentChange = 0;
+    // Initialize raise-related fields using provided data when available
+    const currentSalary = getDisplaySalary(salaryData);
+    employee.proposedRaise = salaryData.proposedRaise ?? 0;
+    employee.newSalary = salaryData.newSalary ?? (employee.proposedRaise ? currentSalary + employee.proposedRaise : currentSalary);
+    if (salaryData.percentChange !== undefined) {
+      employee.percentChange = salaryData.percentChange;
+    } else if (employee.proposedRaise && currentSalary) {
+      employee.percentChange = (employee.proposedRaise / currentSalary) * 100;
+    } else {
+      employee.percentChange = 0;
+    }
+
+    employee.salaryRecommendation = salaryData.salaryRecommendation;
+    employee.adjustmentNotes = salaryData.adjustmentNotes;
 
     // Set default retention risk if not provided
     if (!performanceData?.retentionRisk) {
@@ -272,9 +282,11 @@ export class DataJoiner {
           timeInRole: salaryRow.timeInRole || 0,
           performanceRating: performanceRow.performanceRating,
           retentionRisk: performanceRow.retentionRisk || 50,
-          proposedRaise: 0,
-          newSalary: salaryRow.baseSalary || 0,
-          percentChange: 0,
+          proposedRaise: salaryRow.proposedRaise ?? 0,
+          newSalary: salaryRow.newSalary ?? salaryRow.baseSalary || 0,
+          percentChange: salaryRow.percentChange ?? 0,
+          salaryRecommendation: salaryRow.salaryRecommendation,
+          adjustmentNotes: salaryRow.adjustmentNotes,
           businessImpactScore: performanceRow.businessImpactScore,
           salaryGradeMin: salaryRow.salaryGradeMin,
           salaryGradeMid: salaryRow.salaryGradeMid,
@@ -315,9 +327,11 @@ export class DataJoiner {
           // Preserve performance-related fields if the salary file already contained them
           performanceRating: (salaryRow as any).performanceRating,
           retentionRisk: (salaryRow as any).retentionRisk ?? 50, // Default medium risk
-          proposedRaise: 0,
-          newSalary: salaryRow.baseSalary || 0,
-          percentChange: 0,
+          proposedRaise: salaryRow.proposedRaise ?? 0,
+          newSalary: salaryRow.newSalary ?? salaryRow.baseSalary || 0,
+          percentChange: salaryRow.percentChange ?? 0,
+          salaryRecommendation: salaryRow.salaryRecommendation,
+          adjustmentNotes: salaryRow.adjustmentNotes,
           businessImpactScore: (salaryRow as any).businessImpactScore,
           salaryGradeMin: salaryRow.salaryGradeMin,
           salaryGradeMid: salaryRow.salaryGradeMid,

--- a/src/services/proposalImporter.ts
+++ b/src/services/proposalImporter.ts
@@ -13,6 +13,8 @@ export interface ProposalData {
   name?: string;
   currentSalary?: number;
   currency?: string;
+  salaryRecommendation?: string;
+  adjustmentNotes?: string;
 }
 
 // Result of proposal import operation
@@ -40,23 +42,28 @@ const PROPOSAL_COLUMN_MAPPINGS: Record<string, keyof ProposalData> = {
   'employee id': 'employeeId',
   'emp_id': 'employeeId',
   'id': 'employeeId',
+  'associate id': 'employeeId',
+  'associate_id': 'employeeId',
   
   // Name for validation
   'employee full name': 'name',
   'name': 'name',
   'full_name': 'name',
   'employee_name': 'name',
+  'associate': 'name',
   
   // Proposed salary fields
   'proposed raise (percent)': 'proposedRaisePercent',
   'proposed_raise_percent': 'proposedRaisePercent',
   'raise_percent': 'proposedRaisePercent',
   'raise percentage': 'proposedRaisePercent',
+  'merit increase %': 'proposedRaisePercent',
   
   'proposed salary': 'proposedSalary',
   'proposed_salary': 'proposedSalary',
   'new_salary': 'proposedSalary',
   'new salary': 'proposedSalary',
+  'new base pay all countries': 'proposedSalary',
   
   'proposed comparatio': 'proposedComparatio',
   'proposed_comparatio': 'proposedComparatio',
@@ -67,15 +74,21 @@ const PROPOSAL_COLUMN_MAPPINGS: Record<string, keyof ProposalData> = {
   'proposed_raise': 'proposedRaise',
   'raise_amount': 'proposedRaise',
   'raise amount': 'proposedRaise',
+  'merit increase amount': 'proposedRaise',
   
   // Current salary for validation
   'base pay all countries': 'currentSalary',
   'base_salary': 'currentSalary',
   'current_salary': 'currentSalary',
   'salary': 'currentSalary',
+  'current base pay all countries': 'currentSalary',
   
   // Currency
   'currency': 'currency',
+
+  // Additional proposal details
+  'merit increase priority/recommendation': 'salaryRecommendation',
+  'salary adjustment notes': 'adjustmentNotes',
 };
 
 export class ProposalImporter {
@@ -299,6 +312,14 @@ export class ProposalImporter {
             (proposal.proposedRaise * (employee.baseSalary || 0) / (employee.baseSalaryUSD || 1));
           updatedEmployee.comparatio = Math.round((newSalaryOriginal / employee.salaryGradeMid) * 100);
         }
+      }
+
+      if (proposal.salaryRecommendation !== undefined) {
+        (updatedEmployee as any).salaryRecommendation = proposal.salaryRecommendation;
+      }
+
+      if (proposal.adjustmentNotes !== undefined) {
+        (updatedEmployee as any).adjustmentNotes = proposal.adjustmentNotes;
       }
 
       return updatedEmployee;

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -20,6 +20,8 @@ export interface Employee {
   proposedRaise: number;
   newSalary: number;
   percentChange: number;
+  salaryRecommendation?: string;
+  adjustmentNotes?: string;
   businessImpactScore?: number; // Manager input
   salaryGradeMin?: number;
   salaryGradeMid?: number;
@@ -57,6 +59,11 @@ export interface SalarySheetRow {
   salary?: number; // Full-time salary (for comparatio calculations)
   fte?: number; // Full-time equivalent factor
   comparatio?: number;
+  proposedRaise?: number;
+  newSalary?: number;
+  percentChange?: number;
+  salaryRecommendation?: string;
+  adjustmentNotes?: string;
   salaryGradeMin?: number;
   salaryGradeMid?: number;
   salaryGradeMax?: number;


### PR DESCRIPTION
## Summary
- extend employee data model with salaryRecommendation and adjustmentNotes
- parse Workday Salary Review sheets and manager proposals including merit increase fields
- handle new columns in proposal importer and tests for old/new formats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b99b31d47c832f83547ba7f50622a0